### PR TITLE
seting the cursor position to be between paired keys

### DIFF
--- a/main.js
+++ b/main.js
@@ -54,7 +54,7 @@ define(function (require, exports, module) {
         // set cursor if just pairs
         if (selection.length < 3) {
             var pos = editor._codeMirror.getCursor("start");
-            pos.ch += 1;
+            pos.ch -= 1;
             editor._codeMirror.setCursor(pos);
         }
     }


### PR DESCRIPTION
The cursor was being set to be after the two paired keys and not between them.
This little change fix that
